### PR TITLE
fix post like

### DIFF
--- a/helpers/posts.js
+++ b/helpers/posts.js
@@ -164,21 +164,19 @@ exports.addPostLike = async function (req, res) {
   resMessage = "";
   try {
     let post = await postModel.findById(post_id);
+    let postContent;
     likedUsers = await post.get("userLikes");
 
     if (!likedUsers.includes(authorEmail)) {
-      await post.updateOne({ $inc: { likes: 1 } }, { new: true });
-      await post.updateOne({ $push: { userLikes: authorEmail } }, { new: true });
+      postContent = await postModel.findByIdAndUpdate(post_id, { $inc: { likes: 1 }, $push: { userLikes: authorEmail }  }, { new: true });
       resMessage = "Incremented post likes.";
     } else {
-      await post.updateOne({ $inc: { likes: -1 } }, { new: true });
-      await post.updateOne({ $pull: { userLikes: authorEmail } }, { new: true });
+      postContent = await postModel.findByIdAndUpdate(post_id, { $inc: { likes: -1 }, $pull: { userLikes: authorEmail } }, { new: true });
       resMessage = "Removed user's like.";
     }
-    await post.save()
     return res.status(201).json({
       message: resMessage,
-      post,
+      post: postContent,
     });
   } catch (err) {
     return res.status(400).json({


### PR DESCRIPTION
The problem with the original version was after the post being saved by post.save(), the document is still the old one. So, my brute-force approach is to call findById again and get the newest document.

Result before fix:
![image](https://user-images.githubusercontent.com/52658897/125182623-6ccac600-e1c4-11eb-987f-9de6c40f0152.png)


Result after fix:
![image](https://user-images.githubusercontent.com/52658897/125182582-12316a00-e1c4-11eb-8aa5-9956c68701f6.png)

TODO:
The number of element in `userLikes` is alwasy one more than the number of `likes`. Might be an issue for this specific document though.
