### PR TITLE
changed getPostsPage

### DIFF
--- a/helpers/postsPagination.js
+++ b/helpers/postsPagination.js
@@ -18,8 +18,7 @@ exports.getPostsPage = async ({
   // interactedPosts,
   // likedPosts,
   // commentedPosts
-}
-) => {
+}) => {
   try {
     let level = {
       nextPage: nextPage,


### PR DESCRIPTION
I am still confused about the getPostsPage function to be honest. The parameters needed for getPostsPage is different from what is passed in in the getPosts function. I just used the parameters passed in to call the pagination and it seems like we are able to reach the end of page:

<img width="1368" alt="Screen Shot 2021-11-15 at 9 24 36 PM" src="https://user-images.githubusercontent.com/69881587/141927152-849cfd77-3687-410f-a3a2-b674fab498a0.png">

Really don't know if this is what we want though

And so sorry for pushing directly to the master, really don't know why that happened...
